### PR TITLE
Add get_slot_str utility

### DIFF
--- a/deploy/utils.py
+++ b/deploy/utils.py
@@ -112,6 +112,34 @@ def get_slot_value(handler_input, slot_name: str, default_value: Any = None) -> 
     except (AttributeError, KeyError):
         return default_value
 
+def get_slot_str(handler_input, slot_name: str) -> Optional[str]:
+    """Safely extract a slot string from the handler input.
+
+    This helper abstracts the differences between the ask-sdk ``Slot`` object
+    and a simple ``dict`` representation. ``None`` is returned if the slot or
+    value cannot be found.
+
+    Args:
+        handler_input: The Alexa handler input object.
+        slot_name: Name of the slot to retrieve.
+
+    Returns:
+        Optional[str]: The slot value as a string or ``None``.
+    """
+    try:
+        slots = handler_input.request_envelope.request.intent.slots or {}
+    except AttributeError:
+        return None
+
+    slot = slots.get(slot_name)
+    if slot is None:
+        return None
+
+    if isinstance(slot, dict):
+        return slot.get("value")
+
+    return getattr(slot, "value", None)
+
 def get_user_id(handler_input) -> Optional[str]:
     """
     Safely extract the user ID from an Alexa request.

--- a/utils.py
+++ b/utils.py
@@ -112,6 +112,34 @@ def get_slot_value(handler_input, slot_name: str, default_value: Any = None) -> 
     except (AttributeError, KeyError):
         return default_value
 
+def get_slot_str(handler_input, slot_name: str) -> Optional[str]:
+    """Safely extract a slot string from the handler input.
+
+    This helper abstracts the differences between the ask-sdk ``Slot`` object
+    and a simple ``dict`` representation. ``None`` is returned if the slot or
+    value cannot be found.
+
+    Args:
+        handler_input: The Alexa handler input object.
+        slot_name: Name of the slot to retrieve.
+
+    Returns:
+        Optional[str]: The slot value as a string or ``None``.
+    """
+    try:
+        slots = handler_input.request_envelope.request.intent.slots or {}
+    except AttributeError:
+        return None
+
+    slot = slots.get(slot_name)
+    if slot is None:
+        return None
+
+    if isinstance(slot, dict):
+        return slot.get("value")
+
+    return getattr(slot, "value", None)
+
 def get_user_id(handler_input) -> Optional[str]:
     """
     Safely extract the user ID from an Alexa request.


### PR DESCRIPTION
## Summary
- add `get_slot_str()` helper in utils module
- mirror `get_slot_str()` into deployment utils

## Testing
- `python -m py_compile utils.py deploy/utils.py lambda_function.py`
- `flake8 utils.py deploy/utils.py` *(fails: line too long, unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_684c4a6c7e7c8333a0cf26ecb42e3ca6