### PR TITLE
Ensure progress always tracked when sessions end

### DIFF
--- a/deploy/lambda_function.py
+++ b/deploy/lambda_function.py
@@ -822,10 +822,15 @@ class CancelOrStopIntentHandler(AbstractRequestHandler):
         # Check if we're in a session
         from session_flow import get_session_state
         session_state = get_session_state(handler_input)
-        
+
         if session_state and not session_state.completed:
+            was_complete = session_state.is_complete()
             # End the current session
             speech_text, _ = end_session(handler_input)
+            try:
+                finish_session(session_state.user_id, session_state.exercise_type, completed=was_complete)
+            except Exception as e:
+                logger.error(f"Error logging finished session: {e}")
         else:
             # Just say goodbye
             speech_text = "Goodbye! Remember that regular rehabilitation exercises are important for your recovery."

--- a/deploy/progress_tracker.py
+++ b/deploy/progress_tracker.py
@@ -181,6 +181,31 @@ def log_session_completion(user_id: str, exercise_type: str = "physical") -> boo
         print(f"Error logging session completion: {str(e)}")
         return False
 
+
+def finish_session(user_id: str, exercise_type: str, completed: bool = True) -> bool:
+    """Finish a rehabilitation session and update counters.
+
+    This is a thin wrapper around :func:`log_session_completion` that allows
+    callers to conditionally update the user's session counters. If
+    ``completed`` is ``False`` the function simply returns ``True`` without
+    touching the counters.  This enables callers such as the Stop intent
+    handler to avoid double counting when a session is ended early.
+
+    Args:
+        user_id: The Alexa user identifier.
+        exercise_type: The type of exercise session.
+        completed: Whether the session was fully completed.
+
+    Returns:
+        bool: ``True`` on success, ``False`` otherwise.
+    """
+
+    if not completed:
+        # Nothing to update if the session wasn't completed.
+        return True
+
+    return log_session_completion(user_id, exercise_type)
+
 def log_partial_session(user_id: str, completed: int, total: int, exercise_type: str = "physical") -> bool:
     """
     Log a partially completed rehabilitation session.

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -772,10 +772,15 @@ class CancelOrStopIntentHandler(AbstractRequestHandler):
         # Check if we're in a session
         from session_flow import get_session_state
         session_state = get_session_state(handler_input)
-        
+
         if session_state and not session_state.completed:
+            was_complete = session_state.is_complete()
             # End the current session
             speech_text, _ = end_session(handler_input)
+            try:
+                finish_session(session_state.user_id, session_state.exercise_type, completed=was_complete)
+            except Exception as e:
+                logger.error(f"Error logging finished session: {e}")
         else:
             # Just say goodbye
             speech_text = "Goodbye! Remember that regular rehabilitation exercises are important for your recovery."

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -181,6 +181,31 @@ def log_session_completion(user_id: str, exercise_type: str = "physical") -> boo
         print(f"Error logging session completion: {str(e)}")
         return False
 
+
+def finish_session(user_id: str, exercise_type: str, completed: bool = True) -> bool:
+    """Finish a rehabilitation session and update counters.
+
+    This is a thin wrapper around :func:`log_session_completion` that allows
+    callers to conditionally update the user's session counters. If
+    ``completed`` is ``False`` the function simply returns ``True`` without
+    touching the counters.  This enables callers such as the Stop intent
+    handler to avoid double counting when a session is ended early.
+
+    Args:
+        user_id: The Alexa user identifier.
+        exercise_type: The type of exercise session.
+        completed: Whether the session was fully completed.
+
+    Returns:
+        bool: ``True`` on success, ``False`` otherwise.
+    """
+
+    if not completed:
+        # Nothing to update if the session wasn't completed.
+        return True
+
+    return log_session_completion(user_id, exercise_type)
+
 def log_partial_session(user_id: str, completed: int, total: int, exercise_type: str = "physical") -> bool:
     """
     Log a partially completed rehabilitation session.


### PR DESCRIPTION
## Summary
- add `finish_session` helper in both progress tracker modules
- log session completion from Cancel/Stop handler using `finish_session`
- call the helper when ending a session to keep statistics accurate

## Testing
- `python -m py_compile progress_tracker.py deploy/progress_tracker.py lambda_function.py deploy/lambda_function.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c51e999f883338b65e6788474bb9e