### PR TITLE
Refactor start handlers and update models

### DIFF
--- a/deploy/lambda_function.py
+++ b/deploy/lambda_function.py
@@ -178,59 +178,11 @@ class StartSessionIntentHandler(AbstractRequestHandler):
         else:
             return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
 
-class StartPhysicalTherapyIntentHandler(AbstractRequestHandler):
-    """Handler for StartPhysicalTherapyIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartPhysicalTherapyIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'physical'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
-
-class StartSpeechTherapyIntentHandler(AbstractRequestHandler):
-    """Handler for StartSpeechTherapyIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartSpeechTherapyIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'speech'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
-
-class StartCognitiveExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for StartCognitiveExerciseIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartCognitiveExerciseIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'cognitive'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
 
 class NextExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for NextExerciseIntent (renamed from NextStepIntent)"""
+    """Handler for NextExerciseIntent"""
     def can_handle(self, handler_input):
-        return (is_intent_name("NextExerciseIntent")(handler_input) or
-                is_intent_name("NextStepIntent")(handler_input))  # Support both for backward compatibility
+        return is_intent_name("NextExerciseIntent")(handler_input)
 
     def handle(self, handler_input):
         speech_text, should_end_session = next_exercise(handler_input)
@@ -243,10 +195,9 @@ class NextExerciseIntentHandler(AbstractRequestHandler):
             ).response
 
 class RepeatExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for RepeatExerciseIntent (renamed from RepeatStepIntent)"""
+    """Handler for RepeatExerciseIntent"""
     def can_handle(self, handler_input):
-        return (is_intent_name("RepeatExerciseIntent")(handler_input) or
-                is_intent_name("RepeatStepIntent")(handler_input))  # Support both for backward compatibility
+        return is_intent_name("RepeatExerciseIntent")(handler_input)
 
     def handle(self, handler_input):
         speech_text, should_end_session = repeat_exercise(handler_input)
@@ -985,10 +936,8 @@ class CatchAllExceptionHandler(AbstractExceptionHandler):
 
 # Register request handlers
 sb.add_request_handler(LaunchRequestHandler())
+sb.add_request_handler(EndSessionIntentHandler())
 sb.add_request_handler(StartSessionIntentHandler())
-sb.add_request_handler(StartPhysicalTherapyIntentHandler())
-sb.add_request_handler(StartSpeechTherapyIntentHandler())
-sb.add_request_handler(StartCognitiveExerciseIntentHandler())
 sb.add_request_handler(NextExerciseIntentHandler())
 sb.add_request_handler(RepeatExerciseIntentHandler())
 sb.add_request_handler(SkipExerciseIntentHandler())
@@ -1006,7 +955,6 @@ sb.add_request_handler(CancelRemindersIntentHandler())
 sb.add_request_handler(CheckProgressIntentHandler())
 sb.add_request_handler(SessionSummaryIntentHandler())
 sb.add_request_handler(GetProgressIntentHandler())
-sb.add_request_handler(EndSessionIntentHandler())
 sb.add_request_handler(HelpIntentHandler())
 sb.add_request_handler(CancelOrStopIntentHandler())
 sb.add_request_handler(FallbackIntentHandler())

--- a/deploy/progress_tracker.py
+++ b/deploy/progress_tracker.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import time
 from typing import Dict, Any, Optional, List
+from decimal import Decimal
 from botocore.exceptions import ClientError
 
 # Import configuration
@@ -103,6 +104,8 @@ def update_profile_attribute(user_id: str, key: str, value: Any):
 
         dynamodb = get_dynamodb_resource()
         table = dynamodb.Table(config.DYNAMO_TABLE_NAME)
+        if isinstance(value, float):
+            value = Decimal(str(value))
         table.update_item(
             Key={'user_id': user_id},
             UpdateExpression=f"SET {key} = :v",

--- a/deploy/utils.py
+++ b/deploy/utils.py
@@ -140,6 +140,23 @@ def get_slot_str(handler_input, slot_name: str) -> Optional[str]:
 
     return getattr(slot, "value", None)
 
+def get_resolved_slot_value(handler_input, slot_name: str) -> Optional[str]:
+    """Return the *resolved* canonical slot value if it exists.
+
+    If no resolution is available this falls back to the raw slot value.
+    """
+    try:
+        slot = handler_input.request_envelope.request.intent.slots.get(slot_name)
+        if not slot:
+            return None
+        if slot.resolutions and slot.resolutions.resolutions_per_authority:
+            for res in slot.resolutions.resolutions_per_authority:
+                if res.status.code.value == "ER_SUCCESS_MATCH":
+                    return res.values[0].value.name
+        return slot.value
+    except AttributeError:
+        return None
+
 def get_user_id(handler_input) -> Optional[str]:
     """
     Safely extract the user ID from an Alexa request.

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -192,59 +192,11 @@ class StartSessionIntentHandler(AbstractRequestHandler):
         else:
             return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
 
-class StartPhysicalTherapyIntentHandler(AbstractRequestHandler):
-    """Handler for StartPhysicalTherapyIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartPhysicalTherapyIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'physical'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
-
-class StartSpeechTherapyIntentHandler(AbstractRequestHandler):
-    """Handler for StartSpeechTherapyIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartSpeechTherapyIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'speech'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
-
-class StartCognitiveExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for StartCognitiveExerciseIntent"""
-    def can_handle(self, handler_input):
-        return is_intent_name("StartCognitiveExerciseIntent")(handler_input)
-
-    def handle(self, handler_input):
-        user_id = handler_input.request_envelope.session.user.user_id
-        exercise_type = 'cognitive'
-
-        speech_text, should_end_session = start_session(handler_input, user_id, exercise_type)
-
-        if should_end_session:
-            return handler_input.response_builder.speak(speech_text).set_should_end_session(True).response
-        else:
-            return handler_input.response_builder.speak(speech_text).ask("Say 'next exercise' when you're ready to continue.").response
 
 class NextExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for NextExerciseIntent (renamed from NextStepIntent)"""
+    """Handler for NextExerciseIntent"""
     def can_handle(self, handler_input):
-        return (is_intent_name("NextExerciseIntent")(handler_input) or
-                is_intent_name("NextStepIntent")(handler_input))  # Support both for backward compatibility
+        return is_intent_name("NextExerciseIntent")(handler_input)
 
     def handle(self, handler_input):
         speech_text, should_end_session = next_exercise(handler_input)
@@ -257,10 +209,9 @@ class NextExerciseIntentHandler(AbstractRequestHandler):
             ).response
 
 class RepeatExerciseIntentHandler(AbstractRequestHandler):
-    """Handler for RepeatExerciseIntent (renamed from RepeatStepIntent)"""
+    """Handler for RepeatExerciseIntent"""
     def can_handle(self, handler_input):
-        return (is_intent_name("RepeatExerciseIntent")(handler_input) or
-                is_intent_name("RepeatStepIntent")(handler_input))  # Support both for backward compatibility
+        return is_intent_name("RepeatExerciseIntent")(handler_input)
 
     def handle(self, handler_input):
         speech_text, should_end_session = repeat_exercise(handler_input)
@@ -1011,9 +962,6 @@ class CatchAllExceptionHandler(AbstractExceptionHandler):
 sb.add_request_handler(LaunchRequestHandler())
 sb.add_request_handler(EndSessionIntentHandler())
 sb.add_request_handler(StartSessionIntentHandler())
-sb.add_request_handler(StartPhysicalTherapyIntentHandler())
-sb.add_request_handler(StartSpeechTherapyIntentHandler())
-sb.add_request_handler(StartCognitiveExerciseIntentHandler())
 sb.add_request_handler(NextExerciseIntentHandler())
 sb.add_request_handler(RepeatExerciseIntentHandler())
 sb.add_request_handler(SkipExerciseIntentHandler())

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import time
 from typing import Dict, Any, Optional, List
+from decimal import Decimal
 from botocore.exceptions import ClientError
 
 # Import configuration
@@ -103,6 +104,8 @@ def update_profile_attribute(user_id: str, key: str, value: Any):
 
         dynamodb = get_dynamodb_resource()
         table = dynamodb.Table(config.DYNAMO_TABLE_NAME)
+        if isinstance(value, float):
+            value = Decimal(str(value))
         table.update_item(
             Key={'user_id': user_id},
             UpdateExpression=f"SET {key} = :v",

--- a/skill-package/interactionModels/custom/en-GB.json
+++ b/skill-package/interactionModels/custom/en-GB.json
@@ -54,25 +54,36 @@
             { "name":"strokeCategory","type":"StrokeExerciseCategory"}
           ],
           "samples":[
-            "begin my {exerciseType} rehab session",
-            "start {strokeCategory} training",
-            "I want to do {strokeCategory} {exerciseType}",
-            "help me with {strokeCategory}"
+            "start {exerciseType} therapy",
+            "start {exerciseType}",
+            "start {exerciseType} exercises",
+            "begin {exerciseType} session",
+            "start therapy",
+            "begin rehab session"
           ]
         },
         {
           "name": "ReportPainIntent",
           "slots":[ { "name":"body","type":"BodyArea"} ],
           "samples":[
-            "my {body} hurts", "I feel pain in my {body}", 
+            "my {body} hurts", "I feel pain in my {body}",
             "this exercise hurts"
+          ]
+        },
+        {
+          "name": "ReportFatigueIntent",
+          "slots":[{"name":"score","type":"AMAZON.NUMBER"}],
+          "samples":[
+            "my fatigue is {score}",
+            "I'm at {score} out of ten",
+            "I'm tired"
           ]
         },
         {
           "name": "AskWhyIntent",
           "slots":[],
           "samples":[
-            "why do I need this exercise", 
+            "why do I need this exercise",
             "what is the benefit of this",
             "how does this help recovery"
           ]

--- a/skill-package/interactionModels/custom/en-US.json
+++ b/skill-package/interactionModels/custom/en-US.json
@@ -54,25 +54,36 @@
             { "name":"strokeCategory","type":"StrokeExerciseCategory"}
           ],
           "samples":[
-            "begin my {exerciseType} rehab session",
-            "start {strokeCategory} training",
-            "I want to do {strokeCategory} {exerciseType}",
-            "help me with {strokeCategory}"
+            "start {exerciseType} therapy",
+            "start {exerciseType}",
+            "start {exerciseType} exercises",
+            "begin {exerciseType} session",
+            "start therapy",
+            "begin rehab session"
           ]
         },
         {
           "name": "ReportPainIntent",
           "slots":[ { "name":"body","type":"BodyArea"} ],
           "samples":[
-            "my {body} hurts", "I feel pain in my {body}", 
+            "my {body} hurts", "I feel pain in my {body}",
             "this exercise hurts"
+          ]
+        },
+        {
+          "name": "ReportFatigueIntent",
+          "slots":[{"name":"score","type":"AMAZON.NUMBER"}],
+          "samples":[
+            "my fatigue is {score}",
+            "I'm at {score} out of ten",
+            "I'm tired"
           ]
         },
         {
           "name": "AskWhyIntent",
           "slots":[],
           "samples":[
-            "why do I need this exercise", 
+            "why do I need this exercise",
             "what is the benefit of this",
             "how does this help recovery"
           ]

--- a/utils.py
+++ b/utils.py
@@ -140,56 +140,22 @@ def get_slot_str(handler_input, slot_name: str) -> Optional[str]:
 
     return getattr(slot, "value", None)
 
-def get_resolved_slot_value(handler_input, slot_name: str, fallback_to_value: bool = True) -> Optional[str]:
-    """Return the resolved canonical slot value if available.
+def get_resolved_slot_value(handler_input, slot_name: str) -> Optional[str]:
+    """Return the *resolved* canonical slot value if it exists.
 
-    This helper looks at the slot resolutions to find the canonical value
-    for a slot. If a resolution with status ``ER_SUCCESS_MATCH`` is found,
-    the resolved name is returned in lower case.  If no successful
-    resolution is present and ``fallback_to_value`` is ``True``, the raw
-    slot value is returned instead.
-
-    Args:
-        handler_input: The Alexa handler input object.
-        slot_name: Name of the slot to retrieve.
-        fallback_to_value: Whether to fall back to the raw slot value when
-            no resolution is available.
-
-    Returns:
-        Optional[str]: The resolved or raw slot value in lower case, or
-            ``None`` if not found.
+    If no resolution is available this falls back to the raw slot value.
     """
     try:
-        slots = handler_input.request_envelope.request.intent.slots or {}
+        slot = handler_input.request_envelope.request.intent.slots.get(slot_name)
+        if not slot:
+            return None
+        if slot.resolutions and slot.resolutions.resolutions_per_authority:
+            for res in slot.resolutions.resolutions_per_authority:
+                if res.status.code.value == "ER_SUCCESS_MATCH":
+                    return res.values[0].value.name
+        return slot.value
     except AttributeError:
         return None
-
-    slot = slots.get(slot_name)
-    if slot is None:
-        return None
-
-    # Support both ask-sdk ``Slot`` objects and dict representations
-    if isinstance(slot, dict):
-        resolutions = slot.get("resolutions")
-        value = slot.get("value")
-    else:
-        resolutions = getattr(slot, "resolutions", None)
-        value = getattr(slot, "value", None)
-
-    if resolutions and getattr(resolutions, "resolutions_per_authority", None):
-        for res in resolutions.resolutions_per_authority:
-            try:
-                if res.status.code == "ER_SUCCESS_MATCH" and res.values:
-                    resolved_name = res.values[0].value.name
-                    if resolved_name:
-                        return resolved_name.lower()
-            except AttributeError:
-                continue
-
-    if fallback_to_value and value:
-        return str(value).lower()
-
-    return None
 
 def get_user_id(handler_input) -> Optional[str]:
     """


### PR DESCRIPTION
## Summary
- streamline StartSession routing and drop old start handlers
- expand session-start utterances and expose ReportFatigueIntent
- add slot resolution helper
- store float values as Decimal in DynamoDB

## Testing
- `python -m py_compile lambda_function.py progress_tracker.py utils.py deploy/lambda_function.py deploy/progress_tracker.py deploy/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68543fba5e548333b0ddfbe028b7ccaf